### PR TITLE
Bug fixes and extended support

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -10,8 +10,9 @@
 	"releasenote": "See https://github.com/misprintt/mockatoo/blob/master/CHANGES.md",
 	"version": "3.2.1",
 	"url": "http://github.com/misprintt/mockatoo",
-	"dependencies": 
+	"dependencies":
 	{
 		"mconsole": "1.6.1"
+		"tink_macro": "0.13.3"
 	}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -8,7 +8,7 @@
 	"massive"
 ],
 	"releasenote": "See https://github.com/misprintt/mockatoo/blob/master/CHANGES.md",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"url": "http://github.com/misprintt/mockatoo",
 	"dependencies":
 	{

--- a/haxelib.json
+++ b/haxelib.json
@@ -12,7 +12,7 @@
 	"url": "http://github.com/misprintt/mockatoo",
 	"dependencies":
 	{
-		"mconsole": "1.6.1"
+		"mconsole": "1.6.1",
 		"tink_macro": "0.13.3"
 	}
 }

--- a/src/mockatoo/macro/ClassFields.hx
+++ b/src/mockatoo/macro/ClassFields.hx
@@ -10,6 +10,8 @@ import haxe.PosInfos;
 import haxe.macro.Printer;
 import haxe.macro.TypeTools;
 import haxe.ds.StringMap;
+import tink.macro.Types;
+import Type in Enums;
 
 using haxe.macro.Tools;
 using mockatoo.macro.Tools;
@@ -294,10 +296,31 @@ class ClassFields
 
 		for(param in params)
 		{
-			var complexType = convertType(param.t, paramMap);
+			var paramConstraints:Array<ComplexType> = new Array();
+			switch(param.t)
+			{
+				default:
+				case TInst(ct, _):
+					switch(ct.get().kind)
+					{
+						default:
+						case KTypeParameter(constraints):
+							for (c in constraints)
+							{
+								switch(c)
+								{
+									default:
+									case TInst(t, tparams):
+										var type = t.get();
+										var complexType:ComplexType = Types.asComplexType(type.module + '.' + type.name, [for (p in tparams) TPType(Types.toComplex(p))]);
+										paramConstraints.push(complexType);
+								}
+							}
+					}
+			}
 			var result = {
 				name:param.name,
-				constraints:[],
+				constraints:paramConstraints,
 				params:[]
 			}
 			results.push(result);

--- a/src/mockatoo/macro/MockMaker.hx
+++ b/src/mockatoo/macro/MockMaker.hx
@@ -991,11 +991,7 @@ class MockMaker
 				case TInst(t,p): t.get();
 				case TEnum(t,p): t.get();
 				case TType(t,p): t.get();
-				case TAbstract(t,p): 
-					var id = t.get().type.getId().toComplex();
-
-					
-						null;
+				case TAbstract(t,p): null;
 				case _: null;
 			}
 


### PR DESCRIPTION
Fixed null reference error when using abstracts as the parameter of a function.
Support for functions with constraints in type parameters. Used tink macro for this... I know it's an extra dependency, but I didn't feel like copy pasting all the needed code... if it's a problem tell it and I will do it.